### PR TITLE
change the functions the keybinds implementation should overwrite

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -11,13 +11,17 @@ game specific things:
 - A mod menu. Consider using [console_mod_menu](https://github.com/bl-sdk/console_mod_menu/)
   while developing, though you likely want to create a gui version for users.
 
-- A keybind implementation, which overwrites `KeybindType.enable` and `KeybindType.disable`, and
-  sets up some hooks to run the callbacks as appropriate.
+- A keybind implementation, which overwrites `KeybindType._enable` and `KeybindType._disable` (and
+  possibly `KeybindType._rebind`), and sets up some hooks to run the callbacks as appropriate.
 
 - An initialization script. This should import this and the keybind implementation, then find and
-  import all mods, and finally call `mods_base.mod_list.register_base_mod `
+  import all mods, and finally call `mods_base.mod_list.register_base_mod`
 
 # Changelog
+
+### v1.7 (Upcoming)
+- Changed the functions the keybind implementation should overwrite from `KeybindType.enable` to
+  `KeybindType._enable` (+ same for disable). These functions don't need to set `is_enabled`.
 
 ### v1.6
 - Changed default type of `HookType` generic type hint to any, so that by default pre and post hooks

--- a/__init__.py
+++ b/__init__.py
@@ -8,7 +8,7 @@ from unrealsdk.unreal import UObject
 from .dot_sdkmod import open_in_mod_dir
 
 # Need to define a few things first to avoid circular imports
-__version_info__: tuple[int, int] = (1, 6)
+__version_info__: tuple[int, int] = (1, 7)
 __version__: str = f"{__version_info__[0]}.{__version_info__[1]}"
 __author__: str = "bl-sdk"
 

--- a/keybinds.py
+++ b/keybinds.py
@@ -96,19 +96,26 @@ class KeybindType:
 
         super().__setattr__(name, value)
 
-    # These three functions should get replaced by the keybind implementation
-    # The initialization script should make sure to load it before any mods, to make sure they don't
-    # end up with references to these functions
-    # If writing a new implementation, make sure to still set `is_enabled` correctly
     def enable(self) -> None:
         """Enables this keybind."""
-        logging.error("No keybind implementation loaded, unable to enable binds")
+        self._enable()
         self.is_enabled = True
 
     def disable(self) -> None:
         """Disables this keybind."""
-        logging.error("No keybind implementation loaded, unable to disable binds")
+        self._disable()
         self.is_enabled = False
+
+    # These three functions should get replaced by the keybind implementation
+    # The initialization script should make sure to load it before any mods, to make sure they don't
+    # end up with references to these functions
+    def _enable(self) -> None:
+        """Enables this keybind."""
+        logging.error("No keybind implementation loaded, unable to enable binds")
+
+    def _disable(self) -> None:
+        """Disables this keybind."""
+        logging.error("No keybind implementation loaded, unable to disable binds")
 
     def _rebind(self, new_key: str | None) -> None:
         """


### PR DESCRIPTION
this is motivated by the willow2 sdk forgetting to set `is_enabled` - better to set it up in such a way that making a mistake is impossible