### PR TITLE
fix keybind decorator overloads

### DIFF
--- a/keybinds.py
+++ b/keybinds.py
@@ -169,7 +169,7 @@ def keybind(
     description_title: str | None = None,
     is_hidden: bool = False,
     is_rebindable: bool = True,
-    event_filter: None = None,
+    event_filter: None,
 ) -> KeybindType: ...
 
 
@@ -184,7 +184,7 @@ def keybind(
     description_title: str | None = None,
     is_hidden: bool = False,
     is_rebindable: bool = True,
-    event_filter: None = None,
+    event_filter: None,
 ) -> Callable[[KeybindCallback_Event], KeybindType]: ...
 
 


### PR DESCRIPTION
since the default is released, setting the overloads to default none was always wrong

a recent pybind update started detecting this as overlapping signatures - presumably since it throught you didn't need to provide the event arg