### PR TITLE
move a few warnings to use python's system

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -20,7 +20,7 @@ game specific things:
 # Changelog
 
 ### v1.10
-- Linting fixups.
+- Moved a few warnings to go through Python's system, so they get attributed to the right place.
 
 ### v1.9
 - Added a new `CoopSupport.HostOnly` value.

--- a/mod.py
+++ b/mod.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import inspect
 import sys
+import warnings
 from dataclasses import dataclass, field
 from enum import Enum, Flag, auto
 from functools import cache
@@ -18,6 +19,8 @@ from .settings import default_load_mod_settings, default_save_mod_settings
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator, Sequence
+
+_WARNING_SKIPS: tuple[str] = (str(Path(__file__).parent),)
 
 
 class Game(Flag):
@@ -197,9 +200,11 @@ class Mod:
                     case KeybindType() if find_keybinds:
                         new_keybinds.append(value)
                     case GroupedOption() | NestedOption() if find_options:
-                        logging.dev_warning(
+                        warnings.warn(
                             f"{self.name}: {type(value).__name__} instances must be explicitly"
                             f" specified in the options list!",
+                            stacklevel=2,
+                            skip_file_prefixes=_WARNING_SKIPS,
                         )
                     case BaseOption() if find_options:
                         new_options.append(value)

--- a/mod_factory.py
+++ b/mod_factory.py
@@ -3,12 +3,11 @@ import functools
 import inspect
 import operator
 import tomllib
+import warnings
 from collections.abc import Callable, Sequence
 from pathlib import Path
 from types import ModuleType
 from typing import Any, TypedDict
-
-from unrealsdk import logging
 
 from .command import AbstractCommand
 from .dot_sdkmod import open_in_mod_dir
@@ -18,6 +17,8 @@ from .mod import CoopSupport, Game, Mod, ModType
 from .mod_list import deregister_mod, mod_list, register_mod
 from .options import BaseOption, GroupedOption, NestedOption
 from .settings import SETTINGS_DIR
+
+_WARNING_SKIPS: tuple[str] = (str(Path(__file__).parent),)
 
 
 def build_mod[T: Mod = Mod](
@@ -321,9 +322,11 @@ def update_fields_with_module_search(  # noqa: C901 - difficult to split up
                 new_keybinds.append(value)
 
             case GroupedOption() | NestedOption() if find_options:
-                logging.dev_warning(
+                warnings.warn(
                     f"{module.__name__}: {type(value).__name__} instances must be explicitly"
                     f" specified in the options list!",
+                    stacklevel=2,
+                    skip_file_prefixes=_WARNING_SKIPS,
                 )
             case BaseOption() if find_options:
                 new_options.append(value)

--- a/options.py
+++ b/options.py
@@ -1,3 +1,4 @@
+import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import KW_ONLY, dataclass, field
@@ -136,9 +137,10 @@ class ValueOption[J: JSON](BaseOption):
             This option instance.
         """
         if self.on_change is not None:
-            logging.dev_warning(
+            warnings.warn(
                 f"{self.__class__.__qualname__}.__call__ was called on an option which already has"
                 f" a on change callback.",
+                stacklevel=2,
             )
 
         self.on_change = on_change
@@ -385,9 +387,10 @@ class ButtonOption(BaseOption):
             This option instance.
         """
         if self.on_press is not None:
-            logging.dev_warning(
+            warnings.warn(
                 f"{self.__class__.__qualname__}.__call__ was called on an option which already has"
                 f" a on press callback.",
+                stacklevel=2,
             )
 
         self.on_press = on_press


### PR DESCRIPTION
the ones in `options.py` were just plain overlooked
the other two have non-trivial stack levels, which skip file prefixes solves